### PR TITLE
Handle socket disconnect

### DIFF
--- a/src/MQTTClientMbedOs.cpp
+++ b/src/MQTTClientMbedOs.cpp
@@ -27,6 +27,11 @@ int MQTTNetworkMbedOs::read(unsigned char *buffer, int len, int timeout)
         // MQTTClient.readPacket() requires 0 on time out and no data.
         return 0;
     }
+    if (rc == 0) {
+        // A receive size of 0 indicates that the socket
+        // was successfully closed so indicate this to MQTTClient
+        return -1;
+    }
     return rc;
 }
 
@@ -39,6 +44,10 @@ int MQTTNetworkMbedOs::write(unsigned char *buffer, int len, int timeout)
         // time out and no data
         // MQTTClient.writePacket() requires 0 on time out and no data.
         return 0;
+    }
+    if (rc == 0) {
+        // The socket is closed so indicate this to MQTTClient
+        return -1;
     }
     return rc;
 }

--- a/src/MQTTNetwork.h
+++ b/src/MQTTNetwork.h
@@ -35,12 +35,23 @@ public:
 
     int read(unsigned char *buffer, int len, int timeout)
     {
-        return socket->recv(buffer, len);
+        int ret = socket->recv(buffer, len);
+        if (ret == 0) {
+            // A receive size of 0 indicates that the socket
+            // was successfully closed so indicate this to MQTTClient
+            ret = -1;
+        }
+        return ret;
     }
 
     int write(unsigned char *buffer, int len, int timeout)
     {
-        return socket->send(buffer, len);
+        int ret = socket->send(buffer, len);
+        if (ret == 0) {
+            // The socket is closed so indicate this to MQTTClient
+            return -1;
+        }
+        return ret;
     }
 
     int connect(const char *hostname, int port)

--- a/src/MQTTNetworkTLS.h
+++ b/src/MQTTNetworkTLS.h
@@ -35,12 +35,23 @@ public:
 
     int read(unsigned char *buffer, int len, int timeout)
     {
-        return socket->recv(buffer, len);
+        int ret = socket->recv(buffer, len);
+        if (ret == 0) {
+            // A receive size of 0 indicates that the socket
+            // was successfully closed so indicate this to MQTTClient
+            ret = -1;
+        }
+        return ret;
     }
 
     int write(unsigned char *buffer, int len, int timeout)
     {
-        return socket->send(buffer, len);
+        int ret = socket->send(buffer, len);
+        if (ret == 0) {
+            // The socket is closed so indicate this to MQTTClient
+            return -1;
+        }
+        return ret;
     }
 
     int connect(const char *hostname, int port, const char *ssl_ca_pem = NULL,


### PR DESCRIPTION
When socket send or recv return 0 it means that the socket has been closed. Update the MQTT Network handles translate 0 to -1 so it aborts the current MQTT operation rather than retrying it.