### PR TITLE
Wrap the TLS functions with preprocessor macros

### DIFF
--- a/TESTS/mqtt/mqtt/main.cpp
+++ b/TESTS/mqtt/mqtt/main.cpp
@@ -22,6 +22,11 @@
 
 using namespace utest::v1;
 
+#if !defined(MBEDTLS_SSL_CLI_C) && MBED_CONF_MBED_MQTT_TESTS_TLS_ENABLE
+#warning "Cannot run TLS tests (MBED_CONF_MBED_MQTT_TESTS_TLS_ENABLE) with TLS disabled (no MBEDTLS_SSL_CLI_C)"
+#define MBED_CONF_MBED_MQTT_TESTS_TLS_ENABLE false
+#endif
+
 const char *mqtt_global::SSL_CA_PEM =
 
 #ifdef MQTT_TESTS_CA_CERT_FLESPI

--- a/TESTS/mqtt/mqtt/mqtt-sn_new.cpp
+++ b/TESTS/mqtt/mqtt/mqtt-sn_new.cpp
@@ -262,6 +262,7 @@ void MQTTSN_UDP_CONNECT_SUBSCRIBE_PUBLISH()
     socket.close();
 }
 
+#if defined(MBEDTLS_SSL_CLI_C)
 void MQTTSN_DTLS_CONNECT_SUBSCRIBE_PUBLISH()
 {
     NetworkInterface *net = NetworkInterface::get_default_instance();
@@ -278,3 +279,4 @@ void MQTTSN_DTLS_CONNECT_SUBSCRIBE_PUBLISH()
     socket->close();
     delete socket;
 }
+#endif

--- a/TESTS/mqtt/mqtt/mqtt_legacy.cpp
+++ b/TESTS/mqtt/mqtt/mqtt_legacy.cpp
@@ -207,6 +207,7 @@ void MQTT_LEGACY_CONNECT_SUBSCRIBE_PUBLISH_USER_PASSWORD()
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, mqttNet.disconnect());
 }
 
+#if defined(MBEDTLS_SSL_CLI_C)
 void MQTT_LEGACY_TLS_CONNECT_SUBSCRIBE_PUBLISH()
 {
     NetworkInterface *net = NetworkInterface::get_default_instance();
@@ -221,3 +222,4 @@ void MQTT_LEGACY_TLS_CONNECT_SUBSCRIBE_PUBLISH()
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, mqttNet.disconnect());
 }
+#endif

--- a/TESTS/mqtt/mqtt/mqtt_new.cpp
+++ b/TESTS/mqtt/mqtt/mqtt_new.cpp
@@ -194,7 +194,7 @@ void MQTT_CONNECT_SUBSCRIBE_PUBLISH()
 
     socket.close();
 }
-
+#if defined(MBEDTLS_SSL_CLI_C)
 void MQTT_TLS_CONNECT_SUBSCRIBE_PUBLISH()
 {
     NetworkInterface *net = NetworkInterface::get_default_instance();
@@ -211,6 +211,7 @@ void MQTT_TLS_CONNECT_SUBSCRIBE_PUBLISH()
     socket->close();
     delete socket;
 }
+#endif
 
 void MQTT_CONNECT_SUBSCRIBE_PUBLISH_USER_PASSWORD()
 {

--- a/src/MQTTClientMbedOs.cpp
+++ b/src/MQTTClientMbedOs.cpp
@@ -70,12 +70,14 @@ MQTTClient::MQTTClient(TCPSocket *_socket)
     client = new MQTT::Client<MQTTNetworkMbedOs, Countdown, MBED_CONF_MBED_MQTT_MAX_PACKET_SIZE, MBED_CONF_MBED_MQTT_MAX_CONNECTIONS>(*mqttNet);
 };
 
+#if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
 MQTTClient::MQTTClient(TLSSocket *_socket)
 {
     init(_socket);
     mqttNet = new MQTTNetworkMbedOs(socket);
     client = new MQTT::Client<MQTTNetworkMbedOs, Countdown, MBED_CONF_MBED_MQTT_MAX_PACKET_SIZE, MBED_CONF_MBED_MQTT_MAX_CONNECTIONS>(*mqttNet);
 };
+#endif
 
 MQTTClient::MQTTClient(UDPSocket *_socket)
 {
@@ -84,12 +86,14 @@ MQTTClient::MQTTClient(UDPSocket *_socket)
     clientSN = new MQTTSN::Client<MQTTNetworkMbedOs, Countdown, MBED_CONF_MBED_MQTT_MAX_PACKET_SIZE, MBED_CONF_MBED_MQTT_MAX_CONNECTIONS>(*mqttNet);
 };
 
+#if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
 MQTTClient::MQTTClient(DTLSSocket *_socket)
 {
     init(_socket);
     mqttNet = new MQTTNetworkMbedOs(socket);
     clientSN = new MQTTSN::Client<MQTTNetworkMbedOs, Countdown, MBED_CONF_MBED_MQTT_MAX_PACKET_SIZE, MBED_CONF_MBED_MQTT_MAX_CONNECTIONS>(*mqttNet);
 };
+#endif
 
 nsapi_error_t MQTTClient::connect(MQTTPacket_connectData &options)
 {

--- a/src/MQTTClientMbedOs.h
+++ b/src/MQTTClientMbedOs.h
@@ -107,6 +107,7 @@ public:
      * @param _socket socket to be used for communication
      */
     MQTTClient(TCPSocket *_socket);
+#if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
     /**
      * @brief Constructor for the TLSSocket-based communication.
      * MQTT protocol will be used over a secure socket.
@@ -114,6 +115,7 @@ public:
      * @param _socket socket to be used for communication
      */
     MQTTClient(TLSSocket *_socket);
+#endif
     /**
      * @brief Constructor for the UDPSocket-based communication.
      * MQTT-SN protocol will be used.
@@ -121,6 +123,7 @@ public:
      * @param _socket socket to be used for communication
      */
     MQTTClient(UDPSocket *_socket);
+#if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
     /**
      * @brief Constructor for the DTLSSocket-based communication.
      * MQTT-SN protocol will be used over a secure socket.
@@ -128,6 +131,7 @@ public:
      * @param _socket socket to be used for communication
      */
     MQTTClient(DTLSSocket *_socket);
+#endif
 
     /**
      * @brief Connect to the MQTT broker

--- a/src/MQTTNetworkTLS.h
+++ b/src/MQTTNetworkTLS.h
@@ -21,6 +21,8 @@
 #include "NetworkInterface.h"
 #include "TLSSocket.h"
 
+#if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
+
 class MQTTNetworkTLS {
 public:
     MQTTNetworkTLS(NetworkInterface *aNetwork) : network(aNetwork)
@@ -89,4 +91,5 @@ private:
     TLSSocket *socket;
 };
 
+#endif // defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
 #endif // _MQTTNETWORKTLS_H_


### PR DESCRIPTION
Fixes https://github.com/ARMmbed/mbed-mqtt/issues/9.
For platforms which do not use TLS, we should not compile the TLS-related code.