### PR TITLE
Remove string-based API from test files

### DIFF
--- a/TESTS/mqtt/mqtt/main.cpp
+++ b/TESTS/mqtt/mqtt/main.cpp
@@ -318,7 +318,12 @@ utest::v1::status_t test_setup(const size_t number_of_cases)
     NetworkInterface *net = NetworkInterface::get_default_instance();
     nsapi_error_t err = net->connect();
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
-    printf("MBED: TCPClient IP address is '%s'\n", net->get_ip_address());
+
+    SocketAddress addr;
+    err = net->get_ip_address(&addr);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+
+    printf("MBED: TCPClient IP address is '%s'\n", addr.get_ip_address());
 
     // Generate an string of length MAX_MQTT_PACKET_SIZE+1 with alphabet letters.
     char c = 'a';

--- a/TESTS/mqtt/mqtt/mqtt-sn_new.cpp
+++ b/TESTS/mqtt/mqtt/mqtt-sn_new.cpp
@@ -22,7 +22,9 @@
 #define MQTTSN_API_INIT() \
     arrivedcountSN = 0; \
     NetworkInterface *net = NetworkInterface::get_default_instance(); \
-    SocketAddress sockAddr(mqtt_global::hostname, mqtt_global::port_udp); \
+    SocketAddress sockAddr; \
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, net->gethostbyname(mqtt_global::hostname, &sockAddr)); \
+    sockAddr.set_port(mqtt_global::port_udp); \
     UDPSocket socket; \
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, socket.open(net)); \
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, socket.connect(sockAddr)); \
@@ -267,8 +269,11 @@ void MQTTSN_DTLS_CONNECT_SUBSCRIBE_PUBLISH()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     DTLSSocket *socket = new DTLSSocket; // Allocate on heap to avoid stack overflow.
     TEST_ASSERT(NSAPI_ERROR_OK == socket->open(net));
+    SocketAddress addr;
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, net->gethostbyname(mqtt_global::hostname, &addr));
+    addr.set_port(mqtt_global::port_udp);
     TEST_ASSERT(NSAPI_ERROR_OK == socket->set_root_ca_cert(mqtt_global::SSL_CA_PEM));
-    int ret = socket->connect(mqtt_global::hostname, mqtt_global::port_udp);
+    int ret = socket->connect(addr);
     TEST_ASSERT(NSAPI_ERROR_OK == ret);
 
     MQTTClient client(socket);

--- a/TESTS/mqtt/mqtt/mqtt_new.cpp
+++ b/TESTS/mqtt/mqtt/mqtt_new.cpp
@@ -23,8 +23,11 @@
     arrivedcount = 0; \
     NetworkInterface *net = NetworkInterface::get_default_instance(); \
     TCPSocket socket; \
+    SocketAddress addr; \
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, socket.open(net)); \
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, socket.connect(mqtt_global::hostname, mqtt_global::port)); \
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, net->gethostbyname(mqtt_global::hostname, &addr)); \
+    addr.set_port(mqtt_global::port); \
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, socket.connect(addr)); \
     MQTTClient client(&socket); \
     MQTTPacket_connectData data = MQTTPacket_connectData_initializer; \
     MQTT_API_ATTACH_USERNAME_PASSWORD() \
@@ -70,7 +73,8 @@ void MQTT_SUBSCRIBE_NETWORK_NOT_CONNECTED()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     TCPSocket socket;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, socket.open(net));
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_DNS_FAILURE, socket.connect("i.dont.exist", mqtt_global::port));
+    SocketAddress addr; // intentionally empty
+    TEST_ASSERT_NOT_EQUAL(NSAPI_ERROR_OK, socket.connect(addr));
     MQTTClient client(&socket);
     MQTTPacket_connectData data = MQTTPacket_connectData_initializer;
     data.MQTTVersion = 3;
@@ -141,7 +145,7 @@ void MQTT_UNSUBSCRIBE_INVALID()
 void MQTT_PUBLISH()
 {
     MQTT_API_INIT();
-    data.clientID.cstring = (char *)"MQTT_nnPUBLISH";
+    data.clientID.cstring = (char *)"MQTT_PUBLISH";
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, client.connect(data));
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, client.publish(mqtt_global::topic, mqtt_global::default_message));
     MQTT::Message msg = mqtt_global::default_message;
@@ -186,7 +190,11 @@ void MQTT_CONNECT_SUBSCRIBE_PUBLISH()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     TCPSocket socket;
     socket.open(net);
-    socket.connect(mqtt_global::hostname, mqtt_global::port);
+    SocketAddress addr;
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, net->gethostbyname(mqtt_global::hostname, &addr));
+    addr.set_port(mqtt_global::port);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, socket.connect(addr));
+    socket.connect(addr);
 
     MQTTClient client(&socket);
 
@@ -201,7 +209,10 @@ void MQTT_TLS_CONNECT_SUBSCRIBE_PUBLISH()
     TLSSocket *socket = new TLSSocket; // Allocate on heap to avoid stack overflow.
     TEST_ASSERT(NSAPI_ERROR_OK == socket->open(net));
     TEST_ASSERT(NSAPI_ERROR_OK == socket->set_root_ca_cert(mqtt_global::SSL_CA_PEM));
-    int ret = socket->connect(mqtt_global::hostname, mqtt_global::port_tls);
+    SocketAddress addr;
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, net->gethostbyname(mqtt_global::hostname, &addr));
+    addr.set_port(mqtt_global::port_tls);
+    int ret = socket->connect(addr);
     TEST_ASSERT(NSAPI_ERROR_OK == ret);
 
     MQTTClient client(socket);
@@ -217,7 +228,10 @@ void MQTT_CONNECT_SUBSCRIBE_PUBLISH_USER_PASSWORD()
     NetworkInterface *net = NetworkInterface::get_default_instance();
     TCPSocket socket;
     socket.open(net);
-    socket.connect(mqtt_global::hostname, mqtt_global::port);
+    SocketAddress addr;
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, net->gethostbyname(mqtt_global::hostname, &addr));
+    addr.set_port(mqtt_global::port);
+    socket.connect(addr);
 
     MQTTClient client(&socket);
 

--- a/src/MQTTClientMbedOs.cpp
+++ b/src/MQTTClientMbedOs.cpp
@@ -192,9 +192,9 @@ nsapi_error_t MQTTClient::disconnect()
 bool MQTTClient::isConnected()
 {
     if (client != NULL) {
-        return NSAPI_ERROR_UNSUPPORTED;
+        return false;
     } else if (clientSN == NULL) {
-        return NSAPI_ERROR_NO_CONNECTION;
+        return false;
     } else {
         return clientSN->isConnected();
     }
@@ -202,7 +202,6 @@ bool MQTTClient::isConnected()
 
 void MQTTClient::setDefaultMessageHandler(messageHandler mh)
 {
-    nsapi_error_t ret = NSAPI_ERROR_OK;
     if (client != NULL) {
         client->setDefaultMessageHandler(mh);
     } else if (clientSN != NULL) {

--- a/src/MQTTNetwork.h
+++ b/src/MQTTNetwork.h
@@ -60,7 +60,10 @@ public:
         if ((ret = socket->open(network)) != NSAPI_ERROR_OK) {
             return ret;
         }
-        return socket->connect(hostname, port);
+        SocketAddress addr;
+        network->gethostbyname(hostname, &addr);
+        addr.set_port(port);
+        return socket->connect(addr);
     }
 
     int disconnect()

--- a/src/MQTTNetworkTLS.h
+++ b/src/MQTTNetworkTLS.h
@@ -61,6 +61,12 @@ public:
         if (ret < 0) {
             return ret;
         }
+        SocketAddress addr;
+        ret = network->gethostbyname(hostname, &addr);
+        if (ret < 0) {
+            return ret;
+        }
+        addr.set_port(port);
         ret = socket->set_root_ca_cert(ssl_ca_pem);
         if (ret < 0) {
             return ret;
@@ -71,7 +77,7 @@ public:
                 return ret;
             }
         }
-        return socket->connect(hostname, port);
+        return socket->connect(addr);
     }
 
     int disconnect()


### PR DESCRIPTION
When compiling tests I noticed some deprecation warnings, so got rid of them.