### PR TITLE
Fix legacy MQTTNetwork to return DNS failure

### DIFF
--- a/src/MQTTNetwork.h
+++ b/src/MQTTNetwork.h
@@ -61,7 +61,9 @@ public:
             return ret;
         }
         SocketAddress addr;
-        network->gethostbyname(hostname, &addr);
+        if (network->gethostbyname(hostname, &addr) != NSAPI_ERROR_OK) {
+            return NSAPI_ERROR_DNS_FAILURE;
+        }
         addr.set_port(port);
         return socket->connect(addr);
     }


### PR DESCRIPTION
I noticed CI was failing. Accidentaly broken when removing string-based API usage.
I will double check why CI did not report this before merging previous PR.