### PR TITLE
Make isConnected() available for MQTT, not only for MQTT-SN.

### DIFF
--- a/src/MQTTClientMbedOs.cpp
+++ b/src/MQTTClientMbedOs.cpp
@@ -202,10 +202,11 @@ nsapi_error_t MQTTClient::disconnect()
 
 bool MQTTClient::isConnected()
 {
-    if (client != NULL) {
+    if ((client == NULL && clientSN == NULL) || 
+            (client != NULL && clientSN != NULL)){
         return false;
-    } else if (clientSN == NULL) {
-        return false;
+    } else if( client != NULL) {
+        return client->isConnected();
     } else {
         return clientSN->isConnected();
     }

--- a/src/MQTTClientMbedOs.h
+++ b/src/MQTTClientMbedOs.h
@@ -218,7 +218,7 @@ public:
     nsapi_error_t disconnect();
 
     /**
-     * @brief (MQTT-SN) Check whether client is connected to a broker.
+     * @brief Check whether client is connected to a broker.
      * @retval true if the client is connected, false otherwise
      */
     bool isConnected();


### PR DESCRIPTION
This PR is related to https://github.com/coisme/Mbed-to-AWS-IoT/issues/3.

Currently `MQTTClient::isConnected()` can be used with MQTT-SN. This changes are intended to enable `MQTTClient::isConnected()` for both MQTT and MQTT-SN.
