### PR TITLE
Fix to allow MQTT wildcard subscriptions to work with root topic

### DIFF
--- a/paho_mqtt_embedded_c/MQTTClient/src/MQTTClient.h
+++ b/paho_mqtt_embedded_c/MQTTClient/src/MQTTClient.h
@@ -525,6 +525,17 @@ bool MQTT::Client<Network, Timer, a, b>::isTopicMatched(char* topicFilter, MQTTS
         curn++;
     };
 
+    if(*curf != '\0')
+    {
+        //If our topic filter ends with a wildcard '/#' we need to account for that
+        if(*curf == '/')
+        {
+            curf++;
+            if(*curf == '#')
+                curf++;
+        }
+    }
+
     return (curn == curn_end) && (*curf == '\0');
 }
 


### PR DESCRIPTION
Fixing the MQTT wildcard subscriptions to work with the root topic.

More details can be found in this issue: #25 

This fix assumes that subscribing to `topic/#` should receive messages from both `topic` and any wildcard subtopic `topic/#`.
The original code comparison meant that messages delivered to `topic` would not be captured by the isTopicMatched() filter.