### PR TITLE
accumulate reads and use common implementation for read and write

### DIFF
--- a/src/MQTTClientMbedOs.cpp
+++ b/src/MQTTClientMbedOs.cpp
@@ -16,40 +16,16 @@
  */
 
 #include "MQTTClientMbedOs.h"
+#include "MQTTNetworkUtil.h"
 
 int MQTTNetworkMbedOs::read(unsigned char *buffer, int len, int timeout)
 {
-    nsapi_size_or_error_t rc = 0;
-    socket->set_timeout(timeout);
-    rc = socket->recv(buffer, len);
-    if (rc == NSAPI_ERROR_WOULD_BLOCK) {
-        // time out and no data
-        // MQTTClient.readPacket() requires 0 on time out and no data.
-        return 0;
-    }
-    if (rc == 0) {
-        // A receive size of 0 indicates that the socket
-        // was successfully closed so indicate this to MQTTClient
-        return -1;
-    }
-    return rc;
+    return accumulate_mqtt_read(socket, buffer, len, timeout);
 }
 
 int MQTTNetworkMbedOs::write(unsigned char *buffer, int len, int timeout)
 {
-    nsapi_size_or_error_t rc = 0;
-    socket->set_timeout(timeout);
-    rc = socket->send(buffer, len);
-    if (rc == NSAPI_ERROR_WOULD_BLOCK) {
-        // time out and no data
-        // MQTTClient.writePacket() requires 0 on time out and no data.
-        return 0;
-    }
-    if (rc == 0) {
-        // The socket is closed so indicate this to MQTTClient
-        return -1;
-    }
-    return rc;
+    return mqtt_write(socket, buffer, len, timeout);
 }
 
 int MQTTNetworkMbedOs::connect(const char *hostname, int port)

--- a/src/MQTTNetwork.h
+++ b/src/MQTTNetwork.h
@@ -20,6 +20,7 @@
 
 #include "NetworkInterface.h"
 #include "TCPSocket.h"
+#include "MQTTNetworkUtil.h"
 
 class MQTTNetwork {
 public:
@@ -35,23 +36,12 @@ public:
 
     int read(unsigned char *buffer, int len, int timeout)
     {
-        int ret = socket->recv(buffer, len);
-        if (ret == 0) {
-            // A receive size of 0 indicates that the socket
-            // was successfully closed so indicate this to MQTTClient
-            ret = -1;
-        }
-        return ret;
+        return accumulate_mqtt_read(socket, buffer, len, timeout);
     }
 
     int write(unsigned char *buffer, int len, int timeout)
     {
-        int ret = socket->send(buffer, len);
-        if (ret == 0) {
-            // The socket is closed so indicate this to MQTTClient
-            return -1;
-        }
-        return ret;
+        return mqtt_write(socket, buffer, len, timeout);
     }
 
     int connect(const char *hostname, int port)

--- a/src/MQTTNetworkTLS.h
+++ b/src/MQTTNetworkTLS.h
@@ -20,6 +20,7 @@
 
 #include "NetworkInterface.h"
 #include "TLSSocket.h"
+#include "MQTTNetworkUtil.h"
 
 #if defined(MBEDTLS_SSL_CLI_C) || defined(DOXYGEN_ONLY)
 
@@ -37,23 +38,12 @@ public:
 
     int read(unsigned char *buffer, int len, int timeout)
     {
-        int ret = socket->recv(buffer, len);
-        if (ret == 0) {
-            // A receive size of 0 indicates that the socket
-            // was successfully closed so indicate this to MQTTClient
-            ret = -1;
-        }
-        return ret;
+        return accumulate_mqtt_read(socket, buffer, len, timeout);
     }
 
     int write(unsigned char *buffer, int len, int timeout)
     {
-        int ret = socket->send(buffer, len);
-        if (ret == 0) {
-            // The socket is closed so indicate this to MQTTClient
-            return -1;
-        }
-        return ret;
+        return mqtt_write(socket, buffer, len, timeout);
     }
 
     int connect(const char *hostname, int port, const char *ssl_ca_pem = NULL,

--- a/src/MQTTNetworkUtil.h
+++ b/src/MQTTNetworkUtil.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _MQTTNETWORK_UTIL_H_
+#define _MQTTNETWORK_UTIL_H_
+
+/* MQTT doesn't expect nsapi error values so we translate them */
+static int convert_nsapi_error_to_mqtt_error(int nsapi_error)
+{
+    if (nsapi_error == NSAPI_ERROR_WOULD_BLOCK) {
+        /* MQTT expects 0 on timeout */
+        return 0;
+    } else if (nsapi_error == 0) {
+        /* MQTT expect -1 on closed sockets */
+        return -1;
+    }
+    return nsapi_error;
+}
+
+/** Reads data and returns number of bytes read or a translated error that MQTT expects. This will call
+ * read on the socket multiple times until all data is retrieved.
+ *
+ * @tparam SocketType Socket type like TCPSocket.
+ * @param socket Socket to read data from.
+ * @param buffer Buffer to store data.
+ * @param len Length of expected data.
+ * @param timeout Timeout for the operation.
+ * @return Always returns the full length if successful or an error.
+ */
+template<typename SocketType>
+static int accumulate_mqtt_read(SocketType socket, unsigned char *buffer, int len, int timeout)
+{
+    /* TODO: Timout should be applied to whole operation not partial recv */
+    socket->set_timeout(timeout);
+
+    /* MQTT Client expects the full packet so we accumulate until we get all bytes */
+    int remaining = len;
+    while (remaining) {
+        int ret = socket->recv(buffer, remaining);
+        if (ret > 0) {
+            remaining -= ret;
+            buffer += ret;
+        } else {
+            return convert_nsapi_error_to_mqtt_error(ret);
+        }
+    }
+    return len;
+}
+
+/** Sends data and returns number of bytes sent or a translated error that MQTT expects.
+ *
+ * @tparam SocketType Socket type like TCPSocket.
+ * @param socket Socket to send data on.
+ * @param buffer Data to send.
+ * @param len Length of data.
+ * @param timeout Timeout for the operation.
+ * @return Always returns the full length if successful or an error.
+ */
+template<typename SocketType>
+static int mqtt_write(SocketType socket, unsigned char *buffer, int len, int timeout)
+{
+    socket->set_timeout(timeout);
+    int ret = socket->send(buffer, len);
+    if (ret > 0) {
+        return ret;
+    } else {
+        return convert_nsapi_error_to_mqtt_error(ret);
+    }
+}
+
+#endif // _MQTTNETWORK_UTIL_H_

--- a/src/MQTTSNNetworkUDP.h
+++ b/src/MQTTSNNetworkUDP.h
@@ -19,6 +19,7 @@
 #define _MQTTNETWORKUDP_H_
 
 #include "UDPSocket.h"
+#include "MQTTNetworkUtil.h"
 
 class MQTTSNNetworkUDP {
 public:
@@ -35,12 +36,12 @@ public:
 
     int read(unsigned char *buffer, int len, int timeout)
     {
-        return socket->recv(buffer, len);
+        return accumulate_mqtt_read(socket, buffer, len, timeout);
     }
 
     int write(unsigned char *buffer, int len, int timeout)
     {
-        return socket->send(buffer, len);
+        return mqtt_write(socket, buffer, len, timeout);
     }
 
     int connect(const char *hostname, int port)


### PR DESCRIPTION
MQTT expects a full buffer when it does a read. Sockets return whatever is ready which might be less. The Network layer now accumulates the read bytes until the buffer is full.

Since the same problem affects all the implementations I extracted the read and write into common utility functions (as the implementation do not share a common parent class).