### PR TITLE
Fixed Inclusion of Unit Test Library in application code which caused…

### DIFF
--- a/src/MQTTClientMbedOs.h
+++ b/src/MQTTClientMbedOs.h
@@ -22,7 +22,6 @@
 #include <TLSSocket.h>
 #include <DTLSSocket.h>
 #include <UDPSocket.h>
-#include "unity/unity.h"
 
 #include "FP.h"
 #include <MQTTPacket.h>


### PR DESCRIPTION
… issues on certain build processes

Building against GCC_ARM fails due to the inclusion of this file.  As it is a Unit Test library and isn't used in the code, it probably shouldn't be included here.  Removing it clears the issue and the library can be build with GCC_ARM.