### PR TITLE
mbed-os6 compatibility and const-ness for publish

### DIFF
--- a/paho_mqtt_embedded_c/MQTTClient/src/MQTTClient.h
+++ b/paho_mqtt_embedded_c/MQTTClient/src/MQTTClient.h
@@ -178,7 +178,7 @@ public:
      *  @param retained - whether the message should be retained
      *  @return success code -
      */
-    int publish(const char* topicName, void* payload, size_t payloadlen, enum QoS qos = QOS0, bool retained = false);
+    int publish(const char* topicName, const void* payload, size_t payloadlen, enum QoS qos = QOS0, bool retained = false);
 
     /** MQTT Publish - send an MQTT publish packet and wait for all acks to complete for all QoSs
      *  @param topic - the topic to publish to
@@ -189,7 +189,7 @@ public:
      *  @param retained - whether the message should be retained
      *  @return success code -
      */
-    int publish(const char* topicName, void* payload, size_t payloadlen, unsigned short& id, enum QoS qos = QOS1, bool retained = false);
+    int publish(const char* topicName, const void* payload, size_t payloadlen, unsigned short& id, enum QoS qos = QOS1, bool retained = false);
 
     /** MQTT Subscribe - send an MQTT subscribe packet and wait for the suback
      *  @param topicFilter - a topic pattern which can include wildcards
@@ -990,7 +990,7 @@ exit:
 
 
 template<class Network, class Timer, int MAX_MQTT_PACKET_SIZE, int b>
-int MQTT::Client<Network, Timer, MAX_MQTT_PACKET_SIZE, b>::publish(const char* topicName, void* payload, size_t payloadlen, unsigned short& id, enum QoS qos, bool retained)
+int MQTT::Client<Network, Timer, MAX_MQTT_PACKET_SIZE, b>::publish(const char* topicName, const void* payload, size_t payloadlen, unsigned short& id, enum QoS qos, bool retained)
 {
     int rc = FAILURE;
     Timer timer(command_timeout_ms);
@@ -1032,7 +1032,7 @@ exit:
 
 
 template<class Network, class Timer, int MAX_MQTT_PACKET_SIZE, int b>
-int MQTT::Client<Network, Timer, MAX_MQTT_PACKET_SIZE, b>::publish(const char* topicName, void* payload, size_t payloadlen, enum QoS qos, bool retained)
+int MQTT::Client<Network, Timer, MAX_MQTT_PACKET_SIZE, b>::publish(const char* topicName, const void* payload, size_t payloadlen, enum QoS qos, bool retained)
 {
     unsigned short id = 0;  // dummy - not used for anything
     return publish(topicName, payload, payloadlen, id, qos, retained);

--- a/paho_mqtt_embedded_c/MQTTClient/src/mbed/MQTTmbed.h
+++ b/paho_mqtt_embedded_c/MQTTClient/src/mbed/MQTTmbed.h
@@ -18,48 +18,62 @@
 #if !defined(MQTT_MBED_H)
 #define MQTT_MBED_H
 
+#include <chrono>
+
 #include "mbed.h"
 
 class Countdown
 {
 public:
-    Countdown() : t()
-    {
-
-    }
-
+    Countdown() =default;
+    
     Countdown(int ms) : t()
     {
         countdown_ms(ms);
     }
 
+    Countdown(std::chrono::milliseconds ms) : t()
+    {
+        countdown_ms(ms);
+    }
 
     bool expired()
     {
-        return t.read_ms() >= interval_end_ms;
+        return t.elapsed_time() >= interval_end_ms;
     }
 
-    void countdown_ms(unsigned long ms)
+    void countdown_ms(std::chrono::milliseconds ms)
     {
         t.stop();
-        interval_end_ms = ms;
+        interval_end_ms = std::move(ms);
         t.reset();
         t.start();
     }
 
-    void countdown(int seconds)
+    void countdown(std::chrono::seconds seconds)
     {
-        countdown_ms((unsigned long)seconds * 1000L);
+        countdown_ms(std::move(seconds));
+    }
+    
+    void countdown_ms(unsigned long ms)
+    {
+        countdown_ms(std::chrono::milliseconds{ms});
+    }
+    
+    void countdown(size_t seconds)
+    {
+        countdown_ms(std::chrono::seconds{seconds});
     }
 
     int left_ms()
     {
-        return interval_end_ms - t.read_ms();
+        using namespace std::chrono;
+        return duration_cast<milliseconds>(interval_end_ms - t.elapsed_time()).count();
     }
 
 private:
     Timer t;
-    unsigned long interval_end_ms;
+    std::chrono::milliseconds interval_end_ms;
 };
 
 #endif

--- a/paho_mqtt_embedded_c/MQTTPacket/src/MQTTPublish.h
+++ b/paho_mqtt_embedded_c/MQTTPacket/src/MQTTPublish.h
@@ -26,7 +26,7 @@
 #endif
 
 DLLExport int MQTTSerialize_publish(unsigned char* buf, int buflen, unsigned char dup, int qos, unsigned char retained, unsigned short packetid,
-		MQTTString topicName, unsigned char* payload, int payloadlen);
+		MQTTString topicName, const unsigned char* payload, int payloadlen);
 
 DLLExport int MQTTDeserialize_publish(unsigned char* dup, int* qos, unsigned char* retained, unsigned short* packetid, MQTTString* topicName,
 		unsigned char** payload, int* payloadlen, unsigned char* buf, int len);

--- a/paho_mqtt_embedded_c/MQTTPacket/src/MQTTSerializePublish.c
+++ b/paho_mqtt_embedded_c/MQTTPacket/src/MQTTSerializePublish.c
@@ -53,7 +53,7 @@ int MQTTSerialize_publishLength(int qos, MQTTString topicName, int payloadlen)
   * @return the length of the serialized data.  <= 0 indicates error
   */
 int MQTTSerialize_publish(unsigned char* buf, int buflen, unsigned char dup, int qos, unsigned char retained, unsigned short packetid,
-		MQTTString topicName, unsigned char* payload, int payloadlen)
+		MQTTString topicName, const unsigned char* payload, int payloadlen)
 {
 	unsigned char *ptr = buf;
 	MQTTHeader header = {0};


### PR DESCRIPTION
I am using MQTT with mbed-os 6.
Since they changed the time-based API to std::chrono, there are a lot of deprication warnings, which are fixed by this pull request.

Additionally, addes ome constness to publish, so it works with std::string::c_str().