### PR TITLE
Fix typo

### DIFF
--- a/src/MQTTClientMbedOs.cpp
+++ b/src/MQTTClientMbedOs.cpp
@@ -193,7 +193,7 @@ void MQTTClient::setDefaultMessageHandler(messageHandler mh)
     if (client != NULL) {
         client->setDefaultMessageHandler(mh);
     } else if (clientSN != NULL) {
-        client->setDefaultMessageHandler(mh);
+        clientSN->setDefaultMessageHandler(mh);
     }
 }
 


### PR DESCRIPTION
Calling `setDefaultMessageHandler` on a null pointer doesn't make much sense