### PR TITLE
updated for mbed-os-6x

### DIFF
--- a/paho_mqtt_embedded_c/MQTTClient/src/mbed/MQTTmbed.h
+++ b/paho_mqtt_embedded_c/MQTTClient/src/mbed/MQTTmbed.h
@@ -36,7 +36,8 @@ public:
 
     bool expired()
     {
-        return t.read_ms() >= interval_end_ms;
+        // Editied by Fahid Shehzad 20220410, Original: return t.read_ms() >= interval_end_ms;
+        return interval_end_ms - std::chrono::duration_cast<std::chrono::milliseconds>(t.elapsed_time()).count();
     }
 
     void countdown_ms(unsigned long ms)
@@ -54,7 +55,8 @@ public:
 
     int left_ms()
     {
-        return interval_end_ms - t.read_ms();
+        // Editied by Fahid Shehzad 20220410, Original: return t.read_ms() >= interval_end_ms;
+        return interval_end_ms - std::chrono::duration_cast<std::chrono::milliseconds>(t.elapsed_time()).count();
     }
 
 private:


### PR DESCRIPTION
was getting warning from Mbed-Studion, so made the necessary changes - Fahid Shehzad 20220410

[Warning] MQTTmbed.h@57,36: 'read_ms' is deprecated: Use the Chrono-based elapsed_time method. If integer milliseconds are needed, you can use `duration_cast<milliseconds>(elapsed_time()).count()`  [since mbed-os-6.0.0] [-Wdeprecated-declarations]